### PR TITLE
Update application.yaml

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -6,6 +6,14 @@ metadata:
     description: This template creates a Vert.x application providing health check endpoint to be consumed by Kubernetes.
     tags: instant-app
 parameters:
+- name: SUFFIX_NAME
+  description: The suffix name for the template objects
+  displayName: Suffix name
+  value: ''
+- name: RELEASE_VERSION
+  description: The release version number of application
+  displayName: Release version
+  value: 1.0.0
 - name: SOURCE_REPOSITORY_URL
   description: The source URL for the application
   displayName: Source URL
@@ -31,9 +39,10 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: health-check-vertx
+    name: health-check-vertx${SUFFIX_NAME}
     labels:
       booster: health-check-vertx
+      version: ${RELEASE_VERSION}
   spec: {}
 
 - apiVersion: v1
@@ -52,14 +61,15 @@ objects:
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: health-check-vertx
+    name: health-check-vertx-s2i${SUFFIX_NAME}
     labels:
       booster: health-check-vertx
+      version: ${RELEASE_VERSION}
   spec:
     output:
       to:
         kind: ImageStreamTag
-        name: health-check-vertx:latest
+        name: 'health-check-vertx${SUFFIX_NAME}:${RELEASE_VERSION}'
     source:
       git:
         uri: ${SOURCE_REPOSITORY_URL}
@@ -95,7 +105,9 @@ objects:
     labels:
       app: health-check-vertx
       group: io.openshift.booster
-    name: health-check-vertx
+      version: ${RELEASE_VERSION}
+      expose: 'true'
+    name: health-check-vertx${SUFFIX_NAME}
   spec:
     ports:
     - name: http
@@ -112,17 +124,19 @@ objects:
     labels:
       app: health-check-vertx
       group: io.openshift.booster
-    name: health-check-vertx
+    name: health-check-vertx${SUFFIX_NAME}
   spec:
     replicas: 1
     selector:
       app: health-check-vertx
       group: io.openshift.booster
+      version: ${RELEASE_VERSION}
     template:
       metadata:
         labels:
           app: health-check-vertx
           group: io.openshift.booster
+          version: ${RELEASE_VERSION}
       spec:
         containers:
         - env:
@@ -130,7 +144,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: health-check-vertx:master
+          image: ''
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 1
@@ -170,7 +184,7 @@ objects:
           - vertx
         from:
           kind: ImageStreamTag
-          name: health-check-vertx:latest
+          name: 'health-check-vertx${SUFFIX_NAME}:${RELEASE_VERSION}'
 
 - apiVersion: route.openshift.io/v1
   kind: Route
@@ -178,10 +192,11 @@ objects:
     labels:
       app: health-check-vertx
       group: io.openshift.booster
-    name: health-check-vertx
+      version: ${RELEASE_VERSION}
+    name: health-check-vertx${SUFFIX_NAME}
   spec:
     port:
       targetPort: 8080
     to:
       kind: Service
-      name: health-check-vertx
+      name: health-check-vertx${SUFFIX_NAME}


### PR DESCRIPTION
Updating application.yaml according to openshift.io use case

Changes did -

1. Adds parameter - RELEASE_VERSION which is basically the
build number and will be used to differentiate between
the resources of the particular build.

2. Adds parameter - SUFFIX_NAME which is an identifier to
differentiate between the master build or other branches.
More like a master build or PR build. So whenever there is
a change in the resources of a particular branch, it applies
to the resource of that branch only. The SUFFIX_NAME variable
is used in the name of all resources.

3. Adds a field label in image stream to tag the images
generated with the RELEASE_VERSION.

Fixes https://github.com/openshiftio/openshift.io/issues/4500